### PR TITLE
Enable cloning from local directories and git repositories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "cargo-clone"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cargo 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ extern crate rustc_serialize;
 extern crate cargo_clone;
 
 use cargo::core::{SourceId, GitReference};
-use cargo::util::{Config, CliResult, ToUrl};
+use cargo::util::{Config, CliResult, ToUrl, human};
 
 use docopt::Docopt;
 
@@ -108,6 +108,10 @@ pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
         SourceId::for_git(&url, gitref)
     } else if let Some(path) = options.flag_path {
         SourceId::for_path(&config.cwd().join(path))?
+    } else if options.arg_crate == None {
+        return Err(human("must specify a crate to clone from \
+                   crates.io, or use --path or --git to \
+                   specify alternate source").into());
     } else {
         SourceId::crates_io(config)?
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,10 +11,8 @@ extern crate docopt;
 extern crate rustc_serialize;
 extern crate cargo_clone;
 
-use std::io::{self, Write};
-
-use cargo::core::SourceId;
-use cargo::util::{Config, CliResult};
+use cargo::core::{SourceId, GitReference};
+use cargo::util::{Config, CliResult, ToUrl};
 
 use docopt::Docopt;
 
@@ -29,6 +27,12 @@ pub struct Options {
 
     arg_crate: Option<String>,
     flag_vers: Option<String>,
+    flag_git: Option<String>,
+    flag_branch: Option<String>,
+    flag_tag: Option<String>,
+    flag_rev: Option<String>,
+
+    flag_path: Option<String>,
 }
 
 pub const USAGE: &'static str = "
@@ -41,6 +45,13 @@ Options:
     --prefix DIR              Directory to clone the package into
 
     --vers VERS               Specify a version to clone from crates.io
+
+    --git URL                 Git URL to clone the specified crate from
+    --branch BRANCH           Branch to use when cloning from git
+    --tag TAG                 Tag to use when cloning from git
+    --rev SHA                 Specific commit to use when cloning from git
+
+    --path PATH               Filesystem path to local crate to clone
 
     -h, --help                Print this message
     -V, --version             Print version information
@@ -56,8 +67,8 @@ fn main() {
 
     let config = Config::default().expect("Unable to get config.");
 
-    if let Err(e) = execute(options, config) {
-        write!(io::stderr(), "{}\n", e.to_string()).unwrap();
+    if let Err(e) = execute(options, &config) {
+        config.shell().error(e).unwrap();
         std::process::exit(101);
     }
 }
@@ -70,7 +81,7 @@ fn version() -> String {
             option_env!("CARGO_PKG_VERSION_PRE").unwrap_or(""))
 }
 
-pub fn execute(options: Options, config: Config) -> CliResult<Option<()>> {
+pub fn execute(options: Options, config: &Config) -> CliResult<Option<()>> {
     let verbose = match options.flag_verbose {
         Some(v) => if v {1} else {0},
         None => 0,
@@ -83,8 +94,23 @@ pub fn execute(options: Options, config: Config) -> CliResult<Option<()>> {
         false,
     ));
 
-    // Make a SourceId for the central Registry (usually crates.io)
-    let source_id = try!(SourceId::crates_io(&config));
+    let source_id = if let Some(url) = options.flag_git {
+        let url = url.to_url()?;
+        let gitref = if let Some(rev) = options.flag_rev {
+            GitReference::Rev(rev)
+        } else if let Some(tag) = options.flag_tag {
+            GitReference::Tag(tag)
+        } else if let Some(branch) = options.flag_branch {
+            GitReference::Branch(branch)
+        } else {
+            GitReference::Branch("master".to_string())
+        };
+        SourceId::for_git(&url, gitref)
+    } else if let Some(path) = options.flag_path {
+        SourceId::for_path(&config.cwd().join(path))?
+    } else {
+        SourceId::crates_io(config)?
+    };
 
     let krate = options.arg_crate.as_ref().map(|s| &s[..]);
     let prefix = options.flag_prefix.as_ref().map(|s| &s[..]);


### PR DESCRIPTION
Fixes #1 

Note that I used `--path` instead of `--file` for local directories since that's what `cargo install` uses.

Also, instead of printing the error directly, the code now uses `config.shell().error` function for more consistent error reporting with the rest of cargo.
