### PR TITLE
Add support to multiple crates cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ It can be installed using the install subcommand
 
 and can be used like this:
 
-    cargo clone [options] [<crate>]
+    cargo clone [options] [<crate>]...


### PR DESCRIPTION
This Fixes #23 , which request an mutiple crates cloning support.

Changed the args parse rule to make it accepts commands like `cargo clone lib1 lib2 lib3` as a vector and clone them respectively.
Tested in my local env. and it looks fine.

Reviews are welcomed. @JanLikar 