### PR TITLE
Add options for alternative local and remote registries

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,12 @@ pub struct Options {
     flag_rev: Option<String>,
 
     flag_path: Option<String>,
+
+    flag_alt_registry: Option<String>,
+
+    flag_registry_url: Option<String>,
+
+    flag_local_registry: Option<String>,
 }
 
 pub const USAGE: &'static str = "
@@ -55,6 +61,12 @@ Options:
     --rev SHA                 Specific commit to use when cloning from git
 
     --path PATH               Filesystem path to local crate to clone
+
+    --alt-registry NAME       A registry name from Cargo config to clone the specified crate from
+
+    --registry-url URL        A registry url to clone the specified crate from
+
+    --local-registry PATH     A local registry path to clone the specified crate from
 
     -h, --help                Print this message
     -V, --version             Print version information
@@ -122,6 +134,13 @@ pub fn execute(options: Options, config: &mut Config) -> Result<Option<()>> {
         SourceId::for_git(&url, gitref)?
     } else if let Some(path) = options.flag_path {
         SourceId::for_path(&config.cwd().join(path))?
+    } else if let Some(registry) = options.flag_alt_registry.as_ref() {
+        SourceId::alt_registry(config, registry)?
+    } else if let Some(url) = options.flag_registry_url.as_ref() {
+        let url = url.into_url()?;
+        SourceId::for_registry(&url)?
+    } else if let Some(path) = options.flag_local_registry.as_ref() {
+        SourceId::for_local_registry(&config.cwd().join(path))?
     } else if options.arg_crate.len() == 0 {
         bail!(
             "must specify a crate to clone from \


### PR DESCRIPTION
This allows people to experiment with registries they're not familiar with; some examples:

* `cargo clone <some-crate> --registry-url <url>` for links to remote registries' index repos, i.e., `https://dl.cloudsmith.io/public/<org-or-username>/<repo>/cargo/index.git`.
* `cargo clone <some-crate> --alt-registry <registry-from-config>`, where `registry-from-config` is a key to one of the [alternate registry entries in Cargo configuration](https://doc.rust-lang.org/cargo/reference/registries.html#using-an-alternate-registry).
* `cargo clone <some-crate> --local-registry <path>` for [local registry sources](https://doc.rust-lang.org/cargo/reference/source-replacement.html#local-registry-sources).

---

I feel this to be a particularly important use for `cargo-clone` -- it can be particularly helpful for quickly peering into crates whose origin aren't entirely clear, and the open-source culture of Crates.io might not necessarily be present on alternative repositories.

The only unique commit in this PR is the last one (with the `feat` conventional commit prefix). Others were brought in because of a hard dependency on https://github.com/JanLikar/cargo-clone/pull/29/commits/d5d06b07c568bc3f8026cf1fdfdcea5e9bd361be, which should probably be discussed in #28 where I've filed a PR for it. I chose to depend on subsequent commits in that history since there were no conflicts and I hope to just expedite merging this after that #28 is merged. :)