### PR TITLE
Fix clone_directory.

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -12,6 +12,12 @@ main() {
 
     cross test --target $TARGET
     cross test --target $TARGET --release
+
+    # Test that running the binary works in a few common cases.
+    ./target/rls/cargo-clone clone time
+    ./target/rls/cargo-clone clone --prefix /tmp/output/ time
+    mkdir /tmp/clone-into-existing
+    ./target/rls/cargo-clone clone --prefix /tmp/clone-into-existing time
 }
 
 # we don't run the "test phase" when doing deploys


### PR DESCRIPTION
#31 broke the tool by creating the target directory before
calling clone_directory. clone_directory's walk includes the target
directory itself, and so it was calling create_dir on the target
directory, which failed because it already existed.

This changes the semantics so clone_directory expects to always
be called on an existing directory and avoids trying to create it.