### PR TITLE
update cargo version to 0.59

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,9 +89,9 @@ checksum = "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70"
 
 [[package]]
 name = "cargo"
-version = "0.58.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab77eea837b09297f6ad70921e465d77b60eb10380505abc02bd6e66b653704"
+checksum = "d08705bf607eb738364863d8435e69f88dd5c131b7f9752777a7ce328085cf95"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.52"
-cargo = "0.58.0"
+cargo = "0.59.0"
 clap = "2.34.0"
 semver = "1.0.4"
 walkdir = "2.3.2"
 
 [dev-dependencies]
-tempdir = "0.3.5"
+tempdir = "0.3.7"


### PR DESCRIPTION
I am using this crate as a library, so in order to use the latest version of cargo, this library needs to do the same.