### PR TITLE
Build with `--locked` flag during CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --locked --verbose
     - name: Run tests
       run: cargo test --verbose
     - name: Check formatting


### PR DESCRIPTION
This PR makes it possible to spot issues like #45 during continuous integration.
