### PR TITLE
Expose cargo's vendored-openssl feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,7 @@ dependencies = [
  "memchr",
  "num_cpus",
  "opener",
+ "openssl",
  "os_info",
  "percent-encoding",
  "rustc-workspace-hack",
@@ -806,6 +807,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.22.0+1.1.1q"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,6 +824,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,6 @@ walkdir = "2.3.2"
 
 [dev-dependencies]
 tempdir = "0.3.7"
+
+[features]
+vendored-openssl = ["cargo/vendored-openssl"]


### PR DESCRIPTION
Installing openssl on macOS is a massive pain so it's common for applications that depend on `cargo` to expose this alternative.

- https://github.com/kbknapp/cargo-outdated/blob/v0.11.1/Cargo.toml#L50
- https://github.com/rust-secure-code/cargo-geiger/blob/cargo-geiger-0.11.4/cargo-geiger/Cargo.toml#L39
- https://github.com/est31/cargo-udeps/blob/v0.1.32/Cargo.toml#L16
- https://github.com/nabijaczleweli/cargo-update/blob/v8.2.0/Cargo.toml#L92