### PR TITLE
Run clippy on tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,4 +23,4 @@ jobs:
     - name: Check formatting
       run: cargo fmt -- --check
     - name: Run clippy
-      run: cargo clippy
+      run: cargo clippy --all-targets -- -D warnings

--- a/cargo-clone-core/src/lib.rs
+++ b/cargo-clone-core/src/lib.rs
@@ -262,7 +262,6 @@ pub fn parse_name_and_version(spec: &str) -> CargoResult<Crate> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::Path;
     use tempdir::TempDir;
 
     #[test]


### PR DESCRIPTION
I noticed clippy wasn't checking tests.
The `--all-targets` directory should fix it.
Also, with `-- -D warnings` the command returns a non-zero exit code. So, the CI fails if there's a clippy warning.