### PR TITLE
feat: re-export cargo types

### DIFF
--- a/cargo-clone-core/src/lib.rs
+++ b/cargo-clone-core/src/lib.rs
@@ -14,14 +14,19 @@ use std::process::Command;
 use anyhow::{bail, Context};
 
 use cargo::core::dependency::Dependency;
-use cargo::core::source::{Source, SourceId};
+use cargo::core::source::Source;
 use cargo::core::Package;
 use cargo::sources::{PathSource, SourceConfigMap};
-use cargo::util::{CargoResult, Config};
 
 use semver::VersionReq;
 
 use walkdir::WalkDir;
+
+// Re-export cargo types.
+pub use cargo::{
+    core::SourceId,
+    util::{CargoResult, Config},
+};
 
 #[derive(PartialEq, Eq, Debug)]
 pub struct Crate {


### PR DESCRIPTION
Hi! 👋 In this PR we re-export the cargo types that are needed to use this package as a library.
This allows the users of this library to avoid having `cargo` in their Cargo.toml.
Let me know if you have any concerns :)

[![Open Source Saturday](https://img.shields.io/badge/%E2%9D%A4%EF%B8%8F-open%20source%20saturday-F64060.svg)](https://www.meetup.com/it-IT/Open-Source-Saturday-Milano/)