### PR TITLE
invalidate cache less frequently

### DIFF
--- a/cargo-clone-core/src/lib.rs
+++ b/cargo-clone-core/src/lib.rs
@@ -162,6 +162,7 @@ where
     T: Source + 'a,
 {
     let latest = {
+        // Try to retrieve the summary twice.
         match get_latest_summary(name, vers, &mut src)? {
             Some(summary) => Some(summary),
             None => {

--- a/cargo-clone/src/main.rs
+++ b/cargo-clone/src/main.rs
@@ -96,7 +96,7 @@ fn version() -> String {
 }
 
 pub fn execute(matches: clap::ArgMatches, config: &mut Config) -> Result<Option<()>> {
-    let verbose = if matches.is_present("verbose") { 1 } else { 0 };
+    let verbose = u32::from(matches.is_present("verbose"));
 
     config.configure(
         verbose,


### PR DESCRIPTION
Fix https://github.com/JanLikar/cargo-clone/issues/56

Previously, cargo-clone was invalidating the cache before downloading every crate.
Now, I call invalidate_cache only when cargo-clone doesn't find the crate.