### PR TITLE
Specify workspace resolver to clear warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["cargo-clone", "cargo-clone-core"]
+resolver = "2"
 
 [workspace.dependencies]
 anyhow = "1.0.86"


### PR DESCRIPTION
I noticed while building `cargo-clone` these warnings:

```
warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which implies `resolver = "2"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
note: for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
```